### PR TITLE
created ole_dlvr_item_avail_stat_t

### DIFF
--- a/sql/load.sql
+++ b/sql/load.sql
@@ -435,17 +435,45 @@ NULL AS date_updated
 LIMIT 0;
 
 /*ItemStatus*/
+/* 
+ * Pull List only needs to display status labels.
+ * Strategy is to create this table based on the hard-coded values.
+ * The ID for referring tables then can always be computed from the text value of the status of the item.
+ * */
 TRUNCATE TABLE local_ole.ole_dlvr_item_avail_stat_t CASCADE;
-INSERT INTO local_ole.ole_dlvr_item_avail_stat_t
-SELECT
-NULL AS item_avail_stat_id,
-NULL AS obj_id,
-1.0 AS ver_nbr,
-NULL AS item_avail_stat_cd,
-NULL AS item_avail_stat_nm,
-NULL AS row_act_ind,
-NULL AS date_updated
-LIMIT 0;
+WITH item_stats(stat) AS (
+	VALUES
+		('Available'),
+		('Awaiting pickup'),
+		('Awaiting delivery'),
+		('Checked out'),
+		('Claimed returned'),
+		('Declared lost'),
+		('In process'),
+		('In process (non-requestable)'),
+		('In transit'),
+		('Intellectual item'),
+		('Long missing'),
+		('Lost and paid'),
+		('Missing'),
+		('On order'),
+		('Paged'),
+		('Restricted'),
+		('Order closed'),
+		('Unavailable'),
+		('Unknown'),
+		('Withdrawn')
+)
+INSERT INTO local_ole.ole_dlvr_item_avail_stat_t 
+SELECT 
+	md5(stat) AS item_avail_stat_id,
+	stat AS obj_id,
+	1.0 AS ver_nbr,
+	stat AS item_avail_stat_cd,
+	stat AS item_avail_stat_nm,
+	'Y' AS row_act_ind,
+	NULL AS date_updated
+FROM item_stats;
 
 /*ItemType1*/
 TRUNCATE TABLE local_ole.ole_cat_itm_typ_t CASCADE;


### PR DESCRIPTION
Created `ole_dlvr_item_avail_stat_t`.

Pull List application only reports statuses, it does not select based on statuses. Strategy is to draw from the hard-coded item statuses in FOLIO, and generate the ID via MD5 checksum of the status text. That way it will be easy to compute the status ID when we generate `ole_ds_item_t`, we can just compute the checksum from the availability string.

Maintenance: whenever a new code is added to the hard-coded list, we will need to add the new value to the list of `VALUES` in the `WITH` statement.