### PR TITLE
ole_ds_item_t: added shelving_order

### DIFF
--- a/sql/load.sql
+++ b/sql/load.sql
@@ -675,7 +675,7 @@ SELECT
     call_number_type_id::uuid AS call_number_type_id,
     item_level_call_number_prefix AS call_number_prefix,
     item_level_call_number AS call_number,
-    NULL AS shelving_order,
+    items.effective_shelving_order AS shelving_order,
     enumeration AS enumeration,
     chronology AS chronology,
     items.copy_number AS copy_number,


### PR DESCRIPTION
Populate `ole_ds_item_t.shelving_order` from the effective shelving order, available as of Iris.