### PR TITLE
Create extra_tables.sql; added marctab_field_880

### DIFF
--- a/sql/extra_tables.sql
+++ b/sql/extra_tables.sql
@@ -1,0 +1,15 @@
+/*
+ * Extra derived tables for MS Access app queries, not originaly from OLE.
+ * 
+ * We are lazy about defining the columns...
+ */
+
+/*
+ * marc_field_880
+ * Only the 880 fields, supports non-Roman queries, e.g. in Pull List
+ */
+DROP TABLE local_ole.marctab_field_880;
+CREATE TABLE local_ole.marctab_field_880 AS SELECT * FROM public.srs_marctab WHERE field = '880';
+CREATE INDEX ON local_ole.marctab_field_880 (instance_hrid);
+CREATE INDEX ON local_ole.marctab_field_880 (sf);
+VACUUM ANALYZE local_ole.marctab_field_880;


### PR DESCRIPTION
Created new file for derived tables that do not mimic OLE.

Added marctab_field_880 to simplify asking for non-Roman  fields.