### PR TITLE
Change table definition for ole_ds_item_t to allow longer values in num_pieces column.

### DIFF
--- a/sql/add.sql
+++ b/sql/add.sql
@@ -541,7 +541,7 @@ CREATE TABLE local_ole.ole_ds_item_t (
     enumeration VARCHAR(100),
     chronology VARCHAR(100),
     copy_number VARCHAR(20),
-    num_pieces VARCHAR(10),
+    num_pieces VARCHAR(20),
     desc_of_pieces VARCHAR(400),
     purchase_order_line_item_id VARCHAR(45),
     vendor_line_item_id VARCHAR(45),


### PR DESCRIPTION
Original definition was VARCHAR(10) for the column. Changed to VARCHAR(20).