### PR TITLE
Remove foreign key constraint fk_ole_ds_item_t_ole_ds_holdings_t_holdings_id

### DIFF
--- a/sql/add.sql
+++ b/sql/add.sql
@@ -1016,7 +1016,6 @@ ALTER TABLE local_ole.ole_locn_t ADD CONSTRAINT FK_ole_locn_t_ole_locn_t_parent_
 ALTER TABLE local_ole.ole_ds_bib_info_t ADD CONSTRAINT FK_ole_ds_bib_info_t_ole_ds_bib_t_bib_id FOREIGN KEY(bib_id) REFERENCES local_ole.ole_ds_bib_t(bib_id);
 ALTER TABLE local_ole.ole_ds_holdings_t ADD CONSTRAINT FK_ole_ds_holdings_t_ole_ds_bib_t_bib_id FOREIGN KEY(bib_id) REFERENCES local_ole.ole_ds_bib_t(bib_id);
 ALTER TABLE local_ole.ole_ds_holdings_note_t ADD CONSTRAINT FK_ole_ds_holdings_note_t_ole_ds_holdings_t_holdings_id FOREIGN KEY(holdings_id) REFERENCES local_ole.ole_ds_holdings_t(holdings_id);
-ALTER TABLE local_ole.ole_ds_item_t ADD CONSTRAINT FK_ole_ds_item_t_ole_ds_holdings_t_holdings_id FOREIGN KEY(holdings_id) REFERENCES local_ole.ole_ds_holdings_t(holdings_id);
 ALTER TABLE local_ole.ole_ds_item_t ADD CONSTRAINT FK_ole_ds_item_t_ole_ptrn_t_current_borrower FOREIGN KEY(current_borrower) REFERENCES local_ole.ole_ptrn_t(ole_ptrn_id);
 ALTER TABLE local_ole.ole_ds_item_t ADD CONSTRAINT FK_ole_ds_item_t_ole_ptrn_t_proxy_borrower FOREIGN KEY(proxy_borrower) REFERENCES local_ole.ole_ptrn_t(ole_ptrn_id);
 ALTER TABLE local_ole.ole_ds_item_note_t ADD CONSTRAINT FK_ole_ds_item_note_t_ole_ds_item_t_item_id FOREIGN KEY(item_id) REFERENCES local_ole.ole_ds_item_t(item_id);


### PR DESCRIPTION
This constraint prevented the ole_ds_item_t table (and dependent tables) from being built if for some reason the holdings record was not included in ole_ds_holdings_t. One case that caused that was when an instance, holdings, and item record were created after the LDP update began, but before the holdings and item tables were extracted. This addresses Bugzilla ticket [26817](https://trouble.lib.uchicago.edu/bugzilla/show_bug.cgi?id=26817).