### PR TITLE
Update definition of ole_ds_item_t.copy_number to VARCHAR(40)

### DIFF
--- a/sql/add.sql
+++ b/sql/add.sql
@@ -540,7 +540,7 @@ CREATE TABLE local_ole.ole_ds_item_t (
     shelving_order VARCHAR(300),
     enumeration VARCHAR(100),
     chronology VARCHAR(100),
-    copy_number VARCHAR(20),
+    copy_number VARCHAR(40),
     num_pieces TEXT,
     desc_of_pieces VARCHAR(400),
     purchase_order_line_item_id VARCHAR(45),


### PR DESCRIPTION
Avoid failures due to overlong copy numbers in inventory_items.