### PR TITLE
Use inventory_locations.name column instead of description for ole_locn_t.name

### DIFF
--- a/sql/load.sql
+++ b/sql/load.sql
@@ -546,7 +546,7 @@ SELECT
     id AS obj_id,
     1.0 AS ver_nbr,
     replace(code, 'UC/HP/', 'UC/') AS locn_cd,
-    description AS locn_name,
+    name AS locn_name,
     '5' AS level_id,
     NULL AS parent_locn_id,
     CASE WHEN is_active THEN 'Y' ELSE 'N' END AS row_act_ind


### PR DESCRIPTION
`name` is a required property in the FOLIO location schema, `description` is not. This will avoid problems if there is no description.